### PR TITLE
Add PHPUnit configuration and composer setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ A WordPress plugin that automatically changes posts to draft status when they re
 ## Requirements
 
 - WordPress 5.0 or higher
+
+## Running Tests
+
+1. Install the development dependencies:
+
+```bash
+composer install
+```
+
+2. Run the test suite with:
+
+```bash
+composer test
+```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "example/auto-expire-posts",
+    "description": "Auto-Expire Posts WordPress plugin",
+    "type": "wordpress-plugin",
+    "require-dev": {
+        "phpunit/phpunit": "^9",
+        "wp-phpunit/wp-phpunit": "^5"
+    },
+    "scripts": {
+        "test": "phpunit"
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Plugin Tests">
+            <directory suffix=".php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * PHPUnit bootstrap file for Auto-Expire Posts plugin.
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+    $_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+    echo "Could not find $_tests_dir/includes/functions.php, have you installed WordPress test suite?" . PHP_EOL;
+    exit( 1 );
+}
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually load the plugin being tested.
+ */
+function _load_auto_expire_posts_plugin() {
+    require dirname( dirname( __FILE__ ) ) . '/auto-expire-posts.php';
+}
+tests_add_filter( 'muplugins_loaded', '_load_auto_expire_posts_plugin' );
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -1,0 +1,6 @@
+<?php
+class Plugin_Load_Test extends WP_UnitTestCase {
+    public function test_plugin_loaded() {
+        $this->assertTrue( class_exists( 'Auto_Expire_Posts' ) );
+    }
+}


### PR DESCRIPTION
## Summary
- set up Composer with `phpunit` and `wp-phpunit`
- configure phpunit and a basic bootstrap
- add a sample WP unit test
- document running tests

## Testing
- `composer install` *(fails: command not found)*
- `composer test` *(fails: command not found)*